### PR TITLE
changing port numbers in Provider since Localstack changed edge single entry point

### DIFF
--- a/sns/base.tf
+++ b/sns/base.tf
@@ -23,7 +23,7 @@ provider "aws" {
     # s3             = "http://localhost:4566"
     # secretsmanager = "http://localhost:4566"
     # ses            = "http://localhost:4566"
-    sns            = "http://localhost:4575"
+      sns            = "http://localhost:4566"
     # sqs            = "http://localhost:4566"
     # ssm            = "http://localhost:4566"
     # stepfunctions  = "http://localhost:4566"

--- a/sqs/base.tf
+++ b/sqs/base.tf
@@ -9,7 +9,7 @@ provider "aws" {
 
   endpoints {
     # edge = "http://localhost:4566"
-    sns            = "http://localhost:4575"
-    sqs            = "http://localhost:4576"
+    # sns            = "http://localhost:4575"
+    sqs            = "http://localhost:4566"
   }
 }


### PR DESCRIPTION
tl;dr : my fix is just changing the port number (Provider) for `sns` and `sqs` sources to make the test run without error.

hello Samuel!  I've just watched ur talk about Terratest and Localstack and experimented with ur code.

As u said in your talk, there used to be an issue with the Edge port on Localstack. Since then, Localstack fixed it and decided to use a single port for all traffic.

Kindly accept my pull request in hope it will help many developers get trained in testing there IaC :+1: 

Thank your for energy dedicated to help the community!!

info : https://github.com/localstack/localstack/issues/2983